### PR TITLE
Update Makefile to work with variant lua versions. Update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 SHELL:=/bin/bash
 
-lua=lua
-lua_version=`$(lua) -e 'print(string.match(_VERSION, " ([0-9]+[.][0-9]+)"))'`
+lua:=lua
+lua_version:=$(shell $(lua) -e 'print(string.match(_VERSION, " ([0-9]+[.][0-9]+)"))')
 lua_include=/usr/include/lua$(lua_version)
 ydb_dist=$(shell pkg-config --variable=prefix yottadb --silence-errors)
 ifeq (, $(ydb_dist))
@@ -31,3 +31,6 @@ install: yottadb.lua _yottadb.so
 test:
 	rm -f $(ydb_gbldir)
 	source $(ydb_dist)/ydb_env_set && ydb_gbldir=$(ydb_gbldir) $(lua) -l_yottadb -lyottadb tests/test.lua $(TESTS)
+
+vars:
+	@echo -e $(foreach v,$(.VARIABLES),$(if $(filter file, $(origin $(v)) ), '\n$(v)=$(value $(v))') )

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,3 @@ install: yottadb.lua _yottadb.so
 test:
 	rm -f $(ydb_gbldir)
 	source $(ydb_dist)/ydb_env_set && ydb_gbldir=$(ydb_gbldir) $(lua) -l_yottadb -lyottadb tests/test.lua $(TESTS)
-
-vars:
-	@echo -e $(foreach v,$(.VARIABLES),$(if $(filter file, $(origin $(v)) ), '\n$(v)=$(value $(v))') )

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@
 
 SHELL:=/bin/bash
 
+lua=lua
+lua_version=`$(lua) -e 'print(string.match(_VERSION, " ([0-9]+[.][0-9]+)"))'`
+lua_include=/usr/include/lua$(lua_version)
 ydb_dist=$(shell pkg-config --variable=prefix yottadb --silence-errors)
 ifeq (, $(ydb_dist))
 ydb_dist=$(shell pwd)/YDB/install
 endif
 ydb_gbldir=/tmp/lua-yottadb.gld
 
-CFLAGS=-std=c99 -I$(ydb_dist) -I/usr/include/lua5.3 -Wno-discarded-qualifiers
+CFLAGS=-std=c99 -I$(ydb_dist) -I$(lua_include) -Wno-discarded-qualifiers
 LDFLAGS=-L$(ydb_dist) -lyottadb #-Wl,rpath,YDB/install
 
 _yottadb.so: _yottadb.c
@@ -18,8 +21,8 @@ clean:
 	rm -f *.so
 
 PREFIX=/usr/local
-share_dir=$(PREFIX)/share/lua/5.3
-lib_dir=$(PREFIX)/lib/lua/5.3
+share_dir=$(PREFIX)/share/lua/$(lua_version)
+lib_dir=$(PREFIX)/lib/lua/$(lua_version)
 install: yottadb.lua _yottadb.so
 	install -d $(DESTDIR)$(share_dir) $(DESTDIR)$(lib_dir)
 	install _yottadb.so $(DESTDIR)$(lib_dir)
@@ -27,4 +30,4 @@ install: yottadb.lua _yottadb.so
 
 test:
 	rm -f $(ydb_gbldir)
-	source $(ydb_dist)/ydb_env_set && ydb_gbldir=$(ydb_gbldir) lua -l_yottadb -lyottadb tests/test.lua $(TESTS)
+	source $(ydb_dist)/ydb_env_set && ydb_gbldir=$(ydb_gbldir) $(lua) -l_yottadb -lyottadb tests/test.lua $(TESTS)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ Note: these bindings are single-threaded and do not utilize YottaDB's multithrea
 
 ## Requirements
 
-* Lua 5.2 or greater. These bindings were built and tested with Lua 5.3. The *Makefile* assumes
-  you have your Lua headers installed at */usr/include/lua5.3*. If your Lua headers are elsewhere,
-  you can either modify *Makefile* or pass `CFLAGS=-I/path/to/your/lua` to `make`.
+* Lua 5.2 or greater. These bindings were built and tested with Lua 5.3. The Makefile will use
+  your system's lua version by default. To override this, run `make lua=/path/to/lua`.
 * YottaDB 1.34 or later.
+
+The *Makefile* looks for Lua .h files either in your compiler's default include path such as
+/usr/local/include (the lua install default) and also in */usr/include/luaX.X. Where X.X is the lua
+version installed on your system. If your Lua headers are elsewhere, run
+`make lua_include=/path/to/your/lua/headers`.
 
 ## Sample Usage
 


### PR DESCRIPTION
- Pick include path default to match user's default lua, and make it easier to override.
- Update README to match

