### PR TITLE
Fix yottadb.set() to work with binary strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ lua:=lua
 lua_version:=$(shell $(lua) -e 'print(string.match(_VERSION, " ([0-9]+[.][0-9]+)"))')
 lua_include=/usr/include/lua$(lua_version)
 
+#Ensure tests use our own build of yottadb, not the system one
+export LUA_PATH:=./?.lua;../?.lua;;
+export LUA_CPATH:=./?.so;../?.so;;
+
 ydb_dist=$(shell pkg-config --variable=prefix yottadb --silence-errors)
 ifeq (, $(ydb_dist))
 ydb_dist=$(shell pwd)/YDB/install
@@ -29,6 +33,6 @@ install: yottadb.lua _yottadb.so
 	install _yottadb.so $(DESTDIR)$(lib_dir)
 	install yottadb.lua $(DESTDIR)$(share_dir)
 
-test:
+test: _yottadb.so
 	rm -f $(ydb_gbldir)
 	source $(ydb_dist)/ydb_env_set && ydb_gbldir=$(ydb_gbldir) $(lua) -l_yottadb -lyottadb tests/test.lua $(TESTS)

--- a/_yottadb.c
+++ b/_yottadb.c
@@ -99,7 +99,9 @@ static int set(lua_State *L) {
   ydb_buffer_t subsarray[subs_used];
   get_subs(L, subs_used, subsarray);
   ydb_buffer_t value;
-  YDB_STRING_TO_BUFFER(luaL_optstring(L, !lua_isstring(L, 2) ? 3 : 2, ""), &value);
+  size_t length;
+  value.buf_addr = luaL_optlstring(L, !lua_isstring(L, 2) ? 3 : 2, "", &length);
+  value.len_used = value.len_alloc = (unsigned int)length;
   int status = ydb_set_s(&varname, subs_used, subsarray, &value);
   if (status != YDB_OK) {
     error(L, status);

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -163,6 +163,11 @@ function test_set()
   _yottadb.set('testchinese', '你好世界')
   assert(_yottadb.get('testchinese') == '你好世界')
 
+  -- strings with NULs
+  local name, value = 'testnulstring', 'testnul\0string'
+  _yottadb.set(name, value)
+  assert(_yottadb.get(name) == value)
+
   -- Validate inputs.
   validate_varname_inputs(_yottadb.set)
   validate_subsarray_inputs(_yottadb.set)


### PR DESCRIPTION
Fix yottadb.set() which did not work with strings that have nulls; hence you could never store binary strings into yottadb